### PR TITLE
Fix issue that build is lacked in development dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ build-backend = "setuptools.build_meta"
 [dependency-groups]
 dev = [
     "bandit",
+    "build",
     "bump-my-version",
     "cohesion",
     # The coverage==3.5.3 is difficult to analyze its dependencies by dependencies management tool,


### PR DESCRIPTION
This pull request makes a small update to the development dependencies in the `pyproject.toml` file by adding the `build` package to the `dev` dependency group. This will help ensure that development environments have the necessary tooling for building the project.